### PR TITLE
feat: LsBatchSync to fetch single batch of results

### DIFF
--- a/client.go
+++ b/client.go
@@ -195,6 +195,30 @@ func (c *Client) LsSync(ctx context.Context, opts ...LsOption) ([]PinStatusGette
 	return res, <-errCh
 }
 
+// Manual version of Ls that returns a single batch of results and int with total count
+func (c *Client) LsBatchSync(ctx context.Context, opts ...LsOption) ([]PinStatusGetter, int, error) {
+	var res []PinStatusGetter
+
+	settings := new(lsSettings)
+	for _, o := range opts {
+		if err := o(settings); err != nil {
+			return res, 0, err
+		}
+	}
+
+	pinRes, err := c.lsInternal(ctx, settings)
+	if err != nil {
+		return res, 0, err
+	}
+
+	results := pinRes.GetResults()
+	for _, r := range results {
+		res = append(res, &pinStatusObject{r})
+	}
+
+	return res, int(pinRes.Count), nil
+}
+
 func (c *Client) lsInternal(ctx context.Context, settings *lsSettings) (pinResults, error) {
 	getter := c.client.PinsApi.PinsGet(ctx)
 	if len(settings.cids) > 0 {
@@ -257,7 +281,7 @@ func (pinAddOpts) WithName(name string) AddOption {
 	}
 }
 
-func (pinLsOpts) WithOrigins(origins ...multiaddr.Multiaddr) AddOption {
+func (pinAddOpts) WithOrigins(origins ...multiaddr.Multiaddr) AddOption {
 	return func(options *addSettings) error {
 		for _, o := range origins {
 			options.origins = append(options.origins, o.String())
@@ -326,6 +350,7 @@ func (c *Client) DeleteByID(ctx context.Context, pinID string) error {
 	return nil
 }
 
+// TODO: Remove? (not sure what is the purpose of this - it just adds pin, does not modify nro replace anything)
 func (c *Client) Modify(ctx context.Context, pinID string, cid cid.Cid, opts ...AddOption) (PinStatusGetter, error) {
 	settings := new(addSettings)
 	for _, o := range opts {

--- a/client.go
+++ b/client.go
@@ -202,13 +202,13 @@ func (c *Client) LsBatchSync(ctx context.Context, opts ...LsOption) ([]PinStatus
 	settings := new(lsSettings)
 	for _, o := range opts {
 		if err := o(settings); err != nil {
-			return res, 0, err
+			return nil, 0, err
 		}
 	}
 
 	pinRes, err := c.lsInternal(ctx, settings)
 	if err != nil {
-		return res, 0, err
+		return nil, 0, err
 	}
 
 	results := pinRes.GetResults()

--- a/client.go
+++ b/client.go
@@ -350,8 +350,7 @@ func (c *Client) DeleteByID(ctx context.Context, pinID string) error {
 	return nil
 }
 
-// TODO: Remove? (not sure what is the purpose of this - it just adds pin, does not modify nro replace anything)
-func (c *Client) Modify(ctx context.Context, pinID string, cid cid.Cid, opts ...AddOption) (PinStatusGetter, error) {
+func (c *Client) Replace(ctx context.Context, pinID string, cid cid.Cid, opts ...AddOption) (PinStatusGetter, error) {
 	settings := new(addSettings)
 	for _, o := range opts {
 		if err := o(settings); err != nil {


### PR DESCRIPTION
This PR adds function that returns a single batch and an int with total count to indicate if more results match passed query. 

- We need this for `ipfs pin remote service ls --pin-count` in https://github.com/ipfs/go-ipfs/pull/7661
- Enables a consumer of this lib to implement manual pagination or get total pin count in efficient manner.