### PR TITLE
fix: escape HTML in error response body

### DIFF
--- a/client.go
+++ b/client.go
@@ -195,6 +195,30 @@ func (c *Client) LsSync(ctx context.Context, opts ...LsOption) ([]PinStatusGette
 	return res, <-errCh
 }
 
+// Manual version of Ls that returns a single batch of results and int with total count
+func (c *Client) LsBatchSync(ctx context.Context, opts ...LsOption) ([]PinStatusGetter, int, error) {
+	var res []PinStatusGetter
+
+	settings := new(lsSettings)
+	for _, o := range opts {
+		if err := o(settings); err != nil {
+			return res, 0, err
+		}
+	}
+
+	pinRes, err := c.lsInternal(ctx, settings)
+	if err != nil {
+		return res, 0, err
+	}
+
+	results := pinRes.GetResults()
+	for _, r := range results {
+		res = append(res, &pinStatusObject{r})
+	}
+
+	return res, int(pinRes.Count), nil
+}
+
 func (c *Client) lsInternal(ctx context.Context, settings *lsSettings) (pinResults, error) {
 	getter := c.client.PinsApi.PinsGet(ctx)
 	if len(settings.cids) > 0 {
@@ -257,7 +281,7 @@ func (pinAddOpts) WithName(name string) AddOption {
 	}
 }
 
-func (pinLsOpts) WithOrigins(origins ...multiaddr.Multiaddr) AddOption {
+func (pinAddOpts) WithOrigins(origins ...multiaddr.Multiaddr) AddOption {
 	return func(options *addSettings) error {
 		for _, o := range origins {
 			options.origins = append(options.origins, o.String())
@@ -326,6 +350,7 @@ func (c *Client) DeleteByID(ctx context.Context, pinID string) error {
 	return nil
 }
 
+// TODO: Remove? (not sure what is the purpose of this - it just adds pin, does not modify nro replace anything)
 func (c *Client) Modify(ctx context.Context, pinID string, cid cid.Cid, opts ...AddOption) (PinStatusGetter, error) {
 	settings := new(addSettings)
 	for _, o := range opts {

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+	"html/template"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-pinning-service-http-client/openapi"
@@ -423,8 +424,8 @@ func httperr(resp *http.Response, e error) error {
 		reqStr = resp.Request.URL.String()
 	}
 
-	bodystr := string(oerr.Body())
-	relevantErr := fmt.Errorf("{ httpstatus: %s, httpbody: %s, reqstr: %s }", resp.Status, bodystr, reqStr)
+	bodystr := template.HTMLEscapeString(string(oerr.Body()))
+	relevantErr := fmt.Errorf("{ httpstatus: %q, httpbody: %q, reqstr: %q }", resp.Status, bodystr, reqStr)
 	if err != nil {
 		return fmt.Errorf("RelevantInfo : %s, MarshalErr: %s, Err: %w", relevantErr.Error(), err, e)
 	}


### PR DESCRIPTION
This is a basic "better safe than sorry" cleanup of unexpected error responses.

 - To avoid situation where someone uses this as a vector for HTML injection, response is escaped via  `template.HTMLEscapeString`
- To avoid noisy line endings and make it more clear where values start and end, payload is printed with `%q` which adds quotes and replaces line breaks them with `\n`