### PR TITLE
Use RFC3339Nano to format before and after for pagination

### DIFF
--- a/openapi/client.go
+++ b/openapi/client.go
@@ -141,7 +141,7 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 	if reflect.TypeOf(obj).Kind() == reflect.Slice {
 		return strings.Trim(strings.Replace(fmt.Sprint(obj), " ", delimiter, -1), "[]")
 	} else if t, ok := obj.(time.Time); ok {
-		return t.Format(time.RFC3339)
+		return t.Format(time.RFC3339Nano)
 	}
 
 	return fmt.Sprintf("%v", obj)


### PR DESCRIPTION
Formatting with `RFC3339` strips resolution beyond seconds, which breaks pagination for pins created in the same second.