### PR TITLE
Send all the precisions we have in the dates

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,8 +27,7 @@ type Client struct {
 func NewClient(url, bearerToken string) *Client {
 	config := openapi.NewConfiguration()
 	config.UserAgent = UserAgent
-	bearer := fmt.Sprintf("Bearer %s", bearerToken)
-	config.AddDefaultHeader("Authorization", bearer)
+	config.AddDefaultHeader("Authorization", "Bearer "+bearerToken)
 	config.Servers = openapi.ServerConfigurations{
 		openapi.ServerConfiguration{
 			URL: url,

--- a/openapi/client.go
+++ b/openapi/client.go
@@ -120,7 +120,7 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 	if reflect.TypeOf(obj).Kind() == reflect.Slice {
 		return strings.Trim(strings.Replace(fmt.Sprint(obj), " ", delimiter, -1), "[]")
 	} else if t, ok := obj.(time.Time); ok {
-		return t.Format(time.RFC3339)
+		return t.Format(time.RFC3339Nano)
 	}
 
 	return fmt.Sprintf("%v", obj)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.1"
+  "version": "v0.1.2"
 }


### PR DESCRIPTION
Workaround attempt for ipfs/kubo#8762 while `nextToken` is being speced and implemented.

This need testing I'm not sure all pinning services support this date format.